### PR TITLE
Remove Dwave

### DIFF
--- a/ties/ligandmap.py
+++ b/ties/ligandmap.py
@@ -1,10 +1,14 @@
 import matplotlib.pyplot as plt
 import numpy
 import networkx
-import dwave_networkx.algorithms
 import dimod
 import tabulate
 
+dwave = True
+try:
+    import dwave_networkx.algorithms
+except ImportError:
+    dwave = False
 
 class LigandMap():
     """
@@ -59,6 +63,8 @@ class LigandMap():
         self.map = numpy.loadtxt(filename)
 
     def traveling_salesmen(self):
+        if not dwave:
+            raise ValueError('Please install dwave: pip install dwave_networkx')
         print('Traveling Salesmen (QUBO approximation): ')
         ts = dwave_networkx.traveling_salesperson(self.graph, dimod.ExactSolver())
 


### PR DESCRIPTION
Dwave must be installed by pip this seems to be an obstacle for conda-forge. It does not appear to me that the dwave functions are called in normal use to I have added a try/except to the import such that it can be skipped.